### PR TITLE
allow running mediawiki core dependant tests locally

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -21,7 +21,7 @@ cd vendor
 mkdir wikibase
 cd wikibase
 
-cp -r $originalDirectory mediawiki-term-store
+ln -s $originalDirectory mediawiki-term-store
 
 cd mediawiki-term-store
 composer install

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,12 @@ phpcs:
 covers:
 	./vendor/bin/covers-validator
 
+# MediaWiki Core related
+
+init_mw:
+	MW=1.32.1 DBTYPE=sqlite ./.travis.install.sh
+
+test_mw: phpunit_mw
+
+phpunit_mw:
+	php ../phase3/tests/phpunit/phpunit.php -c ../phase3/vendor/wikibase/mediawiki-term-store/phpunit.xml.dist --group MediaWikiCore


### PR DESCRIPTION
You can run once:
`make init_mw`

(version and database type are fixed for now, can be made dynamic if needed as improvement later)

then one can continuously run their tests that are dependent
on MediaWiki core classes (should have @group MediaWikiCore):
`make test_mw`