### PR TITLE
Add MediaWikiNormalizedTermCleaner

### DIFF
--- a/src/PackagePrivate/MediaWikiNormalizedTermCleaner.php
+++ b/src/PackagePrivate/MediaWikiNormalizedTermCleaner.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Wikibase\TermStore\MediaWiki\PackagePrivate;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Wikimedia\Rdbms\DBError;
+use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\ILoadBalancer;
+
+/**
+ * Cleans up the normalized term store after some terms are no longer needed.
+ * Unused term_in_lang, text_in_lang and text rows are automatically removed.
+ * (Unused type rows are never cleaned up.)
+ *
+ * @license GPL-2.0-or-later
+ */
+class MediaWikiNormalizedTermCleaner {
+
+	/** @var ILoadBalancer */
+	private $lb;
+
+	/** @var IDatabase a connection to DB_REPLICA */
+	private $dbr = null;
+
+	/** @var IDatabase a connection to DB_MASTER */
+	private $dbw = null;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(
+		ILoadBalancer $lb,
+		LoggerInterface $logger = null
+	) {
+		$this->lb = $lb;
+		// $this->dbr and $this->dbw are lazily initialized in cleanTerms()
+		$this->logger = $logger ?: new NullLogger();
+	}
+
+	/**
+	 * Delete the specified term_in_lang rows from the database,
+	 * as well as any text_in_lang and text rows that are now unused.
+	 *
+	 * @param int[] $termInLangIds
+	 */
+	public function cleanTerms( array $termInLangIds ) {
+		if ( $this->dbr === null ) {
+			$this->dbr = $this->lb->getConnection( ILoadBalancer::DB_REPLICA );
+			$this->dbw = $this->lb->getConnection( ILoadBalancer::DB_MASTER );
+		}
+
+		try {
+			$this->lb->beginMasterChanges( __METHOD__ );
+			$this->cleanTermInLangIds( $termInLangIds );
+			$this->lb->commitMasterChanges( __METHOD__ );
+		} catch ( DBError $exception ) {
+			$this->lb->rollbackMasterChanges( __METHOD__ );
+			$this->logger->error(
+				'{method}: DBError while cleaning terms {termInLangIds}: {exception}',
+				[
+					'method' => __METHOD__,
+					'termInLangIds' => $termInLangIds,
+					'exception' => $exception
+				]
+			);
+			throw $exception;
+		}
+	}
+
+	/**
+	 * Delete the specified term_in_lang rows from the database,
+	 * as well as any text_in_lang and text rows that are now unused.
+	 *
+	 * @param int[] $termInLangIds
+	 */
+	private function cleanTermInLangIds( array $termInLangIds ) {
+		if ( $termInLangIds === [] ) {
+			return;
+		}
+
+		$this->logger->debug(
+			'{method}: deleting {count} term_in_lang rows',
+			[
+				'method' => __METHOD__,
+				'count' => count( $termInLangIds ),
+			]
+		);
+
+		$potentiallyUnusedTextInLangIds = $this->selectFieldValuesForPrimaryKey(
+			'wbt_term_in_lang',
+			'wbtl_text_in_lang_id',
+			'wbtl_id',
+			$termInLangIds,
+			__METHOD__
+		);
+
+		$this->dbw->delete(
+			'wbt_term_in_lang',
+			[ 'wbtl_id' => $termInLangIds ],
+			__METHOD__
+		);
+
+		$stillUsedTextInLangIds = $this->dbw->selectFieldValues(
+			'wbt_term_in_lang',
+			'wbtl_text_in_lang_id',
+			[ 'wbtl_text_in_lang_id' => $potentiallyUnusedTextInLangIds ],
+			__METHOD__,
+			[
+				/**
+				 * If we try to clean up a text_in_lang whose last use in a term_in_lang we just
+				 * removed, and simultaneously another request adds a new term_in_lang using that
+				 * text_in_lang, we want one of the following to happen:
+				 *
+				 * 1. Our transaction completes first and removes the text_in_lang. The concurrent
+				 *    request blocks until we’re done, then sees that the text_in_lang is gone and
+				 *    creates it (again) as part of inserting the term_in_lang.
+				 * 2. The other transaction completes first and registers another term_in_lang using
+				 *    that text_in_lang. We block until that’s done and then notice the text_in_lang
+				 *    is still used and don’t clean it up.
+				 *
+				 * For this to work, we need to use 'FOR UPDATE' when checking whether a
+				 * text_in_lang is still used in a term_in_lang, and the other request needs to
+				 * ensure during or after insert of the new term_in_lang that the text_in_lang still
+				 * exists, or create it otherwise. This way, either our check here or the other
+				 * request’s insert will block and wait for the other to complete.
+				 */
+				'FOR UPDATE',
+				// 'DISTINCT', // not supported in combination with FOR UPDATE on some DB types
+			]
+		);
+		$unusedTextInLangIds = array_diff(
+			$potentiallyUnusedTextInLangIds,
+			$stillUsedTextInLangIds
+		);
+
+		$this->cleanTextInLangIds( $unusedTextInLangIds );
+	}
+
+	/**
+	 * Delete the specified text_in_lang rows from the database,
+	 * as well as any text rows that are now unused.
+	 *
+	 * @param int[] $textInLangIds
+	 */
+	private function cleanTextInLangIds( array $textInLangIds ) {
+		if ( $textInLangIds === [] ) {
+			return;
+		}
+
+		$this->logger->debug(
+			'{method}: deleting {count} text_in_lang rows',
+			[
+				'method' => __METHOD__,
+				'count' => count( $textInLangIds ),
+			]
+		);
+
+		$potentiallyUnusedTextIds = $this->selectFieldValuesForPrimaryKey(
+			'wbt_text_in_lang',
+			'wbxl_text_id',
+			'wbxl_id',
+			$textInLangIds,
+			__METHOD__
+		);
+
+		$this->dbw->delete(
+			'wbt_text_in_lang',
+			[ 'wbxl_id' => $textInLangIds ],
+			__METHOD__
+		);
+
+		$stillUsedTextIds = $this->dbw->selectFieldValues(
+			'wbt_text_in_lang',
+			'wbxl_text_id',
+			[ 'wbxl_text_id' => $potentiallyUnusedTextIds ],
+			__METHOD__,
+			[
+				'FOR UPDATE', // see comment in cleanTermInLangIds
+				// 'DISTINCT', // not supported in combination with FOR UPDATE on some DB types
+			]
+		);
+		$unusedTextIds = array_diff(
+			$potentiallyUnusedTextIds,
+			$stillUsedTextIds
+		);
+
+		$this->cleanTextIds( $unusedTextIds );
+	}
+
+	/**
+	 * Delete the specified text rows from the database.
+	 *
+	 * @param array $textIds
+	 */
+	private function cleanTextIds( array $textIds ) {
+		if ( $textIds === [] ) {
+			return;
+		}
+
+		$this->logger->debug(
+			'{method}: deleting {count} text rows',
+			[
+				'method' => __METHOD__,
+				'count' => count( $textIds ),
+			]
+		);
+
+		$this->dbw->delete(
+			'wbt_text',
+			[ 'wbx_id' => $textIds ],
+			__METHOD__
+		);
+	}
+
+	/**
+	 * Select the values for a field in rows with the given primary key.
+	 * All the rows with these primary keys should exist in the master database,
+	 * and the selected values should never change.
+	 *
+	 * This initially selects from the replica database,
+	 * only falling back to the master if the replica did not return
+	 * as many rows as there were specified primary key values.
+	 *
+	 * @param string $table
+	 * @param string $selectedVar
+	 * @param string $primaryKeyVar
+	 * @param int[] $primaryKeyValues
+	 * @param string $fname
+	 * @return array
+	 */
+	private function selectFieldValuesForPrimaryKey(
+		$table,
+		$selectedVar,
+		$primaryKeyVar,
+		$primaryKeyValues,
+		$fname = __METHOD__
+	) {
+		$values = $this->dbr->selectFieldValues(
+			$table,
+			$selectedVar,
+			[ $primaryKeyVar => $primaryKeyValues ],
+			$fname
+		);
+
+		if ( count( $values ) < count( $primaryKeyValues ) ) {
+			$this->logger->debug(
+				"{method}: replica only returned {valuesCount} '{selectedVar}' values " .
+					"for {primaryKeyValuesCount} '{primaryKeyVar}' values, " .
+					'falling back to read from master.',
+				[
+					'method' => __METHOD__,
+					'callingMethod' => $fname,
+					'valuesCount' => count( $values ),
+					'selectedVar' => $selectedVar,
+					'primaryKeyValuesCount' => count( $primaryKeyValues ),
+					'primaryKeyVar' => $primaryKeyVar,
+				]
+			);
+			$values = $this->dbw->selectFieldValues(
+				$table,
+				$selectedVar,
+				[ $primaryKeyVar => $primaryKeyValues ],
+				$fname
+			);
+		}
+
+		return $values;
+	}
+
+}

--- a/tests/Integration/MediaWikiNormalizedTermCleanerTest.php
+++ b/tests/Integration/MediaWikiNormalizedTermCleanerTest.php
@@ -1,0 +1,284 @@
+<?php // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols -- see evil hack below
+
+namespace Wikibase\TermStore\MediaWiki\Tests\Integration;
+
+use MediaWikiTestCase;
+use Wikibase\TermStore\MediaWiki\PackagePrivate\MediaWikiNormalizedTermCleaner;
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\Rdbms\IMaintainableDatabase;
+
+// Evil hack because we don’t always have MediaWikiTestCase and `class extends MediaWikiTestCase`
+// crashes even if (because of the special group) we’re not actually going to run the test.
+// This also requires us to disable the PSR1.Files.SideEffects.FoundWithSymbols warning, which
+// otherwise complains about mixing declarations with procedural code; since that warning is
+// reported on line 1, not on the return statement, we have to disable it up there instead of here.
+if ( !class_exists( MediaWikiTestCase::class ) ) {
+	return;
+}
+
+/**
+ * @covers \Wikibase\TermStore\MediaWiki\PackagePrivate\MediaWikiNormalizedTermCleaner
+ *
+ * @group Database
+ * @group TermStoreWithMediaWikiCore
+ *
+ * @license GPL-2.0-or-later
+ */
+class MediaWikiNormalizedTermCleanerTest extends MediaWikiTestCase {
+
+	protected function setUp() {
+		parent::setUp();
+		$this->tablesUsed[] = 'wbt_type';
+		$this->tablesUsed[] = 'wbt_text';
+		$this->tablesUsed[] = 'wbt_text_in_lang';
+		$this->tablesUsed[] = 'wbt_term_in_lang';
+	}
+
+	protected function getSchemaOverrides( IMaintainableDatabase $db ) {
+		return [
+			'scripts' => [ __DIR__ . '/../../src/PackagePrivate/AddNormalizedTermsTablesDDL.sql' ],
+			'create' => [
+				'wbt_type',
+				'wbt_text',
+				'wbt_text_in_lang',
+				'wbt_term_in_lang',
+			],
+		];
+	}
+
+	private function getCleaner(): MediaWikiNormalizedTermCleaner {
+		$lb = $this->createMock( ILoadBalancer::class );
+		$lb->method( 'getConnection' )
+			->willReturn( $this->db );
+		return new MediaWikiNormalizedTermCleaner( $lb );
+	}
+
+	public function testCleanupEverything() {
+		$this->db->insert( 'wbt_type',
+			[ 'wby_name' => 'label' ] );
+		$typeId = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'a label' ] );
+		$text1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'eine Bezeichnung' ] );
+		$text2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+		$textInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+		$textInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang2Id = $this->db->insertId();
+
+		$this->getCleaner()->cleanTerms( [ $termInLang1Id, $termInLang2Id ] );
+
+		$this->assertSelect( 'wbt_text', 'wbx_id', '*', [] );
+		$this->assertSelect( 'wbt_text_in_lang', 'wbxl_id', '*', [] );
+		$this->assertSelect( 'wbt_term_in_lang', 'wbtl_id', '*', [] );
+		$this->assertSelect( 'wbt_type', 'wby_name', '*', [ [ 'label' ] ] );
+	}
+
+	public function testCleanupTermInLangButNoTextInLang() {
+		$this->db->insert( 'wbt_type',
+			[ 'wby_name' => 'label' ] );
+		$type1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_type',
+			[ 'wby_name' => 'description' ] );
+		$type2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'some text' ] );
+		$text1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'etwas Text' ] );
+		$text2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+		$textInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+		$textInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $type1Id, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $type2Id, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $type1Id, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang3Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $type2Id, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang4Id = $this->db->insertId();
+
+		$this->getCleaner()->cleanTerms( [ $termInLang1Id, $termInLang4Id ] );
+
+		$this->assertSelect(
+			'wbt_text',
+			'wbx_id',
+			'*',
+			[ [ $text1Id ], [ $text2Id ] ],
+			[ 'ORDER BY' => 'wbx_id' ]
+		);
+		$this->assertSelect(
+			'wbt_text_in_lang',
+			'wbxl_id',
+			'*',
+			[ [ $textInLang1Id ], [ $textInLang2Id ] ],
+			[ 'ORDER BY' => 'wbxl_id' ]
+		);
+		$this->assertSelect(
+			'wbt_term_in_lang',
+			'wbtl_id',
+			'*',
+			[ [ $termInLang2Id ], [ $termInLang3Id ] ],
+			[ 'ORDER BY' => 'wbtl_id' ]
+		);
+	}
+
+	public function testCleanupOneTextInLangButNoText() {
+		$this->db->insert( 'wbt_type',
+			[ 'wby_name' => 'label' ] );
+		$typeId = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'text' ] );
+		$text1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'Text' ] );
+		$text2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+		$textInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+		$textInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'fr', 'wbxl_text_id' => $text1Id ] );
+		$textInLang3Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang3Id ] );
+		$termInLang3Id = $this->db->insertId();
+
+		$this->getCleaner()->cleanTerms( [ $termInLang1Id ] );
+
+		// $textInLang1Id and $termInLang1Id gone,
+		// but $text1Id still there because referenced by $termInLang3Id
+		$this->assertSelect(
+			'wbt_text',
+			'wbx_id',
+			'*',
+			[ [ $text1Id ], [ $text2Id ] ],
+			[ 'ORDER BY' => 'wbx_id' ]
+		);
+		$this->assertSelect(
+			'wbt_text_in_lang',
+			'wbxl_id',
+			'*',
+			[ [ $textInLang2Id ], [ $textInLang3Id ] ],
+			[ 'ORDER BY' => 'wbxl_id' ]
+		);
+		$this->assertSelect(
+			'wbt_term_in_lang',
+			'wbtl_id',
+			'*',
+			[ [ $termInLang2Id ], [ $termInLang3Id ] ],
+			[ 'ORDER BY' => 'wbtl_id' ]
+		);
+	}
+
+	public function testCleanupOneText() {
+		$this->db->insert( 'wbt_type',
+			[ 'wby_name' => 'label' ] );
+		$typeId = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'text' ] );
+		$text1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'Text' ] );
+		$text2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+		$textInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+		$textInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang2Id = $this->db->insertId();
+
+		$this->getCleaner()->cleanTerms( [ $termInLang1Id ] );
+
+		// $textId1, $textInLang1Id and $termInLang1Id gone
+		$this->assertSelect(
+			'wbt_text',
+			'wbx_id',
+			'*',
+			[ [ $text2Id ] ]
+		);
+		$this->assertSelect(
+			'wbt_text_in_lang',
+			'wbxl_id',
+			'*',
+			[ [ $textInLang2Id ] ]
+		);
+		$this->assertSelect(
+			'wbt_term_in_lang',
+			'wbtl_id',
+			'*',
+			[ [ $termInLang2Id ] ]
+		);
+	}
+
+	public function testCleanupLeavesUnrelatedTextsUntouched() {
+		$this->db->insert( 'wbt_type',
+			[ 'wby_name' => 'label' ] );
+		$typeId = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'a label' ] );
+		$text1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'eine Bezeichnung' ] );
+		$text2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+		$textInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+		$textInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => $typeId, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang1Id = $this->db->insertId();
+
+		$this->getCleaner()->cleanTerms( [ $termInLang1Id ] );
+
+		// $text2Id and $textInLang2Id are not used by any term_in_lang,
+		// but we should not attempt to clean them up
+		$this->assertSelect(
+			'wbt_text',
+			'wbx_id',
+			'*',
+			[ [ $text2Id ] ]
+		);
+		$this->assertSelect(
+			'wbt_text_in_lang',
+			'wbxl_id',
+			'*',
+			[ [ $textInLang2Id ] ]
+		);
+	}
+
+}


### PR DESCRIPTION
This class can be used to remove `term_in_lang` rows that are no longer necessary, automatically cleaning up unneeded rows in the other normalization tables.

Bug: [T221701](https://phabricator.wikimedia.org/T221701)