### PR TITLE
Only test against MediaWiki master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: php
 
 sudo: false
 
+env:
+  - DBTYPE=mysql MW=master
+
+php:
+  - 7.0
+  - 7.3
+
 matrix:
-  include:
-    - env: DBTYPE=mysql; MW=master
-      php: '7.3'
-    - env: DBTYPE=mysql; MW=1.31.0
-      php: '7.0'
   fast_finish: true
 
 install: make init_mw


### PR DESCRIPTION
Wikibase doesn’t support any older MediaWiki releases, so we don’t need to either.