### PR TITLE
Introduce `ci` Makefile goal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ matrix:
 install: make init_mw
 
 script:
-  - make cs
-  - make test
-  - make test_mw
+  - make ci
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci test phpunit cs stan covers init_mw test_mw phpunit_mw
+.PHONY: ci test phpunit cs stan covers init_mw test_mw phpunit_mw ci
 
 DEFAULT_GOAL := check
 
@@ -27,3 +27,5 @@ test_mw: phpunit_mw
 
 phpunit_mw:
 	php .mediawiki/tests/phpunit/phpunit.php -c .mediawiki/vendor/wikibase/mediawiki-term-store/phpunit.xml.dist --group TermStoreWithMediaWikiCore
+
+ci: check test_mw


### PR DESCRIPTION
This can be used to reproduce the same tests as in CI locally, and is more convenient than running `make cs test test_mw` or `make check test_mw` by hand.

---

Kind of a follow-up to #13.