### PR TITLE
Register schema update unconditionally

### DIFF
--- a/src/TermStoreSchemaUpdater.php
+++ b/src/TermStoreSchemaUpdater.php
@@ -17,12 +17,6 @@ class TermStoreSchemaUpdater {
 	}
 
 	private function updateSchema() {
-		if ( !$this->updater->tableExists( 'wbt_item_terms' ) ) {
-			$this->createSchema();
-		}
-	}
-
-	private function createSchema() {
 		$this->updater->addExtensionTable(
 			'wbt_item_terms',
 			__DIR__ . '/PackagePrivate/AddNormalizedTermsTablesDDL.sql'


### PR DESCRIPTION
`DatabaseUpdater::addTable()` already checks if the table exists or not, we’re not supposed to do that check when registering the update (compare [[[Manual:Hooks/LoadExtensionSchemaUpdates#To add a new table]]][1]).

[1]: https://www.mediawiki.org/wiki/Manual:Hooks/LoadExtensionSchemaUpdates#To_add_a_new_table