### PR TITLE
Add TermCleaner interface and in-memory implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 		"ockcyp/covers-validator": "~1.1",
 		"squizlabs/php_codesniffer": "~3.3",
 		"slevomat/coding-standard": "^3.0|~4.5",
-		"mediawiki/mediawiki-codesniffer": "~23.0"
+		"mediawiki/mediawiki-codesniffer": "~23.0",
+		"wikimedia/testing-access-wrapper": "^1.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/PackagePrivate/InMemoryTermIdsAcquirer.php
+++ b/src/PackagePrivate/InMemoryTermIdsAcquirer.php
@@ -2,7 +2,7 @@
 
 namespace Wikibase\TermStore\MediaWiki\PackagePrivate;
 
-class InMemoryTermIdsAcquirer implements TermIdsAcquirer {
+class InMemoryTermIdsAcquirer implements TermIdsAcquirer, TermCleaner {
 
 	private $terms = [];
 	private $lastId = 0;
@@ -25,6 +25,25 @@ class InMemoryTermIdsAcquirer implements TermIdsAcquirer {
 		}
 
 		return $ids;
+	}
+
+	public function cleanTerms( array $termInLangIds ) {
+		$termInLangIdsAsKeys = array_flip( $termInLangIds );
+		foreach ( $this->terms as $type => &$termsOfType ) {
+			foreach ( $termsOfType as $lang => &$termsOfLang ) {
+				foreach ( $termsOfLang as $term => $id ) {
+					if ( array_key_exists( $id, $termInLangIdsAsKeys ) ) {
+						unset( $termsOfLang[$term] );
+					}
+				}
+				if ( $termsOfLang === [] ) {
+					unset( $termsOfType[$lang] );
+				}
+			}
+			if ( $termsOfType === [] ) {
+				unset( $this->terms[$type] );
+			}
+		}
 	}
 
 }

--- a/src/PackagePrivate/MediaWikiNormalizedTermCleaner.php
+++ b/src/PackagePrivate/MediaWikiNormalizedTermCleaner.php
@@ -15,7 +15,7 @@ use Wikimedia\Rdbms\ILoadBalancer;
  *
  * @license GPL-2.0-or-later
  */
-class MediaWikiNormalizedTermCleaner {
+class MediaWikiNormalizedTermCleaner implements TermCleaner {
 
 	/** @var ILoadBalancer */
 	private $lb;
@@ -41,6 +41,11 @@ class MediaWikiNormalizedTermCleaner {
 	/**
 	 * Delete the specified term_in_lang rows from the database,
 	 * as well as any text_in_lang and text rows that are now unused.
+	 *
+	 * It is the caller’s responsibility ensure
+	 * that the term_in_lang rows are no longer referenced anywhere;
+	 * on the other hand, this class takes care that text_in_lang and text rows
+	 * used by other term_in_lang rows are not removed.
 	 *
 	 * @param int[] $termInLangIds
 	 */

--- a/src/PackagePrivate/TermCleaner.php
+++ b/src/PackagePrivate/TermCleaner.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Wikibase\TermStore\MediaWiki\PackagePrivate;
+
+/**
+ * Interface for deleting IDs acquired from a {@link TermIdsAcquirer},
+ * including any further cleanup if necessary.
+ *
+ * @license GPL-2.0-or-later
+ */
+interface TermCleaner {
+
+	/**
+	 * Delete the given term IDs.
+	 * Ensuring that they are unreferenced is the caller’s responsibility.
+	 *
+	 * Depending on the implementation,
+	 * this may include further internal cleanups.
+	 * In that case, the implementation takes care
+	 * that those cleanups do not affect other (not deleted) term IDs.
+	 *
+	 * @param int[] $termInLangIds
+	 */
+	public function cleanTerms( array $termInLangIds );
+
+}

--- a/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
+++ b/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\TermStore\MediaWiki\Tests\Unit\PackagePrivate;
 
 use PHPUnit\Framework\TestCase;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\InMemoryTermIdsAcquirer;
+use Wikimedia\TestingAccessWrapper;
 
 class InMemeoryTermIdsAcquirerTest extends TestCase {
 
@@ -89,6 +90,85 @@ class InMemeoryTermIdsAcquirerTest extends TestCase {
 			count( $ids ),
 			count( array_unique( $ids ) )
 		);
+	}
+
+	public function testCleanTerms_doesNotReuseIds() {
+		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
+
+		$ids1 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [
+				'en' => 'the label',
+				'de' => 'die Bezeichnung',
+			],
+			'alias' => [
+				'en' => [ 'alias', 'another' ],
+			],
+		] );
+		$ids2 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [ 'en' => 'the label' ],
+			'description' => [ 'en' => 'the description' ],
+		] );
+
+		$termIdsAcquirer->cleanTerms( array_merge( $ids1, $ids2 ) );
+
+		$ids3 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [ 'en' => 'the label' ],
+			'description' => [ 'en' => 'the description' ],
+		] );
+		$this->assertGreaterThan( max( max( $ids1 ), max( $ids2 ) ), min( $ids3 ) );
+	}
+
+	public function testCleanTerms_completelyCleansArray() {
+		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
+
+		$ids1 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [
+				'en' => 'the label',
+				'de' => 'die Bezeichnung',
+			],
+			'alias' => [
+				'en' => [ 'alias', 'another' ],
+			],
+		] );
+		$ids2 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [ 'en' => 'the label' ],
+			'description' => [ 'en' => 'the description' ],
+		] );
+
+		$termIdsAcquirer->cleanTerms( array_merge( $ids1, $ids2 ) );
+
+		$this->assertEmpty( TestingAccessWrapper::newFromObject( $termIdsAcquirer )->terms );
+	}
+
+	public function testCleanTerms_keepsOtherIds() {
+		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
+
+		$ids1 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [
+				'en' => 'the label',
+				'de' => 'die Bezeichnung',
+			],
+			'alias' => [
+				'en' => [ 'alias', 'another' ],
+			],
+		] );
+		$ids2 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [ 'en' => 'the label' ],
+			'description' => [ 'en' => 'the description' ],
+		] );
+
+		// Clean up terms related to the first set of IDs,
+		// while keeping the second set of IDs intact.
+		// (Knowing that the intersection of $ids1 and $ids2 should not be cleaned
+		// is the caller’s responsibility, not the cleaner’s; we do it via array_diff.)
+		$idsToClean = array_diff( $ids1, $ids2 );
+		$termIdsAcquirer->cleanTerms( $idsToClean );
+
+		$ids3 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [ 'en' => 'the label' ],
+			'description' => [ 'en' => 'the description' ],
+		] );
+		$this->assertSame( $ids2, $ids3 );
 	}
 
 }


### PR DESCRIPTION
This is based on #10, but I want to get that one merged soon without blocking it on discussions about the two other commits here, so it’s a separate pull request.