### PR TITLE
Improve testCleanTerms_completelyCleansArray

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
 		"ockcyp/covers-validator": "~1.1",
 		"squizlabs/php_codesniffer": "~3.3",
 		"slevomat/coding-standard": "^3.0|~4.5",
-		"mediawiki/mediawiki-codesniffer": "~23.0",
-		"wikimedia/testing-access-wrapper": "^1.0"
+		"mediawiki/mediawiki-codesniffer": "~23.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/PackagePrivate/InMemoryTermIdsAcquirer.php
+++ b/src/PackagePrivate/InMemoryTermIdsAcquirer.php
@@ -47,7 +47,18 @@ class InMemoryTermIdsAcquirer implements TermIdsAcquirer, TermCleaner {
 	}
 
 	public function hasTerms() {
-		return $this->terms !== [];
+		$empty = true;
+		// if there's any leaf element in terms then it's not empty, otherwise we consider
+		// the terms array empty even if it had some sub-arrays that are also empty by
+		// this definition
+		array_walk_recursive(
+			$this->terms,
+			function ( $element ) use ( &$empty ) {
+				$empty = false;
+			}
+		);
+
+		return !$empty;
 	}
 
 }

--- a/src/PackagePrivate/InMemoryTermIdsAcquirer.php
+++ b/src/PackagePrivate/InMemoryTermIdsAcquirer.php
@@ -46,4 +46,8 @@ class InMemoryTermIdsAcquirer implements TermIdsAcquirer, TermCleaner {
 		}
 	}
 
+	public function hasTerms() {
+		return $this->terms !== [];
+	}
+
 }

--- a/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
+++ b/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
@@ -120,7 +120,7 @@ class InMemoryTermIdsAcquirerTest extends TestCase {
 		$this->assertGreaterThan( max( max( $ids1 ), max( $ids2 ) ), min( $ids3 ) );
 	}
 
-	public function testCleanTerms_completelyCleansArray() {
+	public function testHasTerms_returnsFalseAfterCleaningTerms() {
 		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
 
 		$ids = $termIdsAcquirer->acquireTermIds( [
@@ -137,6 +137,23 @@ class InMemoryTermIdsAcquirerTest extends TestCase {
 		$termIdsAcquirer->cleanTerms( $ids );
 
 		$this->assertFalse( $termIdsAcquirer->hasTerms() );
+	}
+
+	public function testHasTerms_returnsTrueAfterAcquiringTermIds() {
+		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
+
+		$ids = $termIdsAcquirer->acquireTermIds( [
+			'label' => [
+				'en' => 'the label',
+				'de' => 'die Bezeichnung',
+			],
+			'alias' => [
+				'en' => [ 'alias', 'another' ],
+			],
+			'description' => [ 'en' => 'the description' ],
+		] );
+
+		$this->assertTrue( $termIdsAcquirer->hasTerms() );
 	}
 
 	public function testCleanTerms_keepsOtherIds() {

--- a/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
+++ b/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
@@ -4,7 +4,6 @@ namespace Wikibase\TermStore\MediaWiki\Tests\Unit\PackagePrivate;
 
 use PHPUnit\Framework\TestCase;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\InMemoryTermIdsAcquirer;
-use Wikimedia\TestingAccessWrapper;
 
 /**
  * @covers \Wikibase\TermStore\MediaWiki\PackagePrivate\InMemoryTermIdsAcquirer
@@ -124,7 +123,7 @@ class InMemoryTermIdsAcquirerTest extends TestCase {
 	public function testCleanTerms_completelyCleansArray() {
 		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
 
-		$ids1 = $termIdsAcquirer->acquireTermIds( [
+		$ids = $termIdsAcquirer->acquireTermIds( [
 			'label' => [
 				'en' => 'the label',
 				'de' => 'die Bezeichnung',
@@ -132,15 +131,12 @@ class InMemoryTermIdsAcquirerTest extends TestCase {
 			'alias' => [
 				'en' => [ 'alias', 'another' ],
 			],
-		] );
-		$ids2 = $termIdsAcquirer->acquireTermIds( [
-			'label' => [ 'en' => 'the label' ],
 			'description' => [ 'en' => 'the description' ],
 		] );
 
-		$termIdsAcquirer->cleanTerms( array_merge( $ids1, $ids2 ) );
+		$termIdsAcquirer->cleanTerms( $ids );
 
-		$this->assertEmpty( TestingAccessWrapper::newFromObject( $termIdsAcquirer )->terms );
+		$this->assertFalse( $termIdsAcquirer->hasTerms() );
 	}
 
 	public function testCleanTerms_keepsOtherIds() {


### PR DESCRIPTION
The two calls to acquireTermIds seemed to be accidental
complexity so I changed to only one call.

I also removed access to the private field as this is surprising
and breaks automated refactoring. New approach has class define
explicitly what can be accessed.

... Just realized:

Since the tested class is an in memory implementation meant
for tests and implements a package private interface, it is
probably better placed in tests/TestDoubles or similar rather
than src/. Lets clean that up in some follow up.