### PR TITLE
Update test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ composer.phar
 composer.lock
 
 vendor/
-mediawiki/
+.mediawiki/
 
 .idea/
-.mediawiki/

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,7 +2,7 @@ build: true
 inherit: true
 
 tools:
-    external_code_coverage: true
+    external_code_coverage: false
     php_code_sniffer: true
     php_cpd: true
     php_cs_fixer: true

--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -32,7 +32,7 @@ ln -s "$originalDirectory" mediawiki-term-store
 
 cd mediawiki-term-store
 
-composer instal
+composer install
 
 cd "$mediawikiDirectory"
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: phpunit
 cs: phpcs
 
 phpunit:
-	./vendor/bin/phpunit --exclude-group TermStoreWithMediaWikiCore
+	./vendor/bin/phpunit
 
 phpcs:
 	./vendor/bin/phpcs -p -s
@@ -26,6 +26,6 @@ init_mw:
 test_mw: phpunit_mw
 
 phpunit_mw:
-	php .mediawiki/tests/phpunit/phpunit.php -c .mediawiki/vendor/wikibase/mediawiki-term-store/phpunit.xml.dist --group TermStoreWithMediaWikiCore
+	php .mediawiki/tests/phpunit/phpunit.php -c .mediawiki/vendor/wikibase/mediawiki-term-store/phpunit.xml.dist ./tests/Integration
 
 ci: check test_mw

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,12 +8,6 @@
         <testsuite name="unit">
             <directory>tests/Unit</directory>
         </testsuite>
-        <testsuite name="integration">
-            <directory>tests/Integration</directory>
-        </testsuite>
-        <testsuite name="system">
-            <directory>tests/System</directory>
-        </testsuite>
     </testsuites>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">

--- a/tests/Integration/MediaWikiNormalizedTermCleanerTest.php
+++ b/tests/Integration/MediaWikiNormalizedTermCleanerTest.php
@@ -7,20 +7,10 @@ use Wikibase\TermStore\MediaWiki\PackagePrivate\MediaWikiNormalizedTermCleaner;
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\Rdbms\IMaintainableDatabase;
 
-// Evil hack because we don’t always have MediaWikiTestCase and `class extends MediaWikiTestCase`
-// crashes even if (because of the special group) we’re not actually going to run the test.
-// This also requires us to disable the PSR1.Files.SideEffects.FoundWithSymbols warning, which
-// otherwise complains about mixing declarations with procedural code; since that warning is
-// reported on line 1, not on the return statement, we have to disable it up there instead of here.
-if ( !class_exists( MediaWikiTestCase::class ) ) {
-	return;
-}
-
 /**
  * @covers \Wikibase\TermStore\MediaWiki\PackagePrivate\MediaWikiNormalizedTermCleaner
  *
  * @group Database
- * @group TermStoreWithMediaWikiCore
  *
  * @license GPL-2.0-or-later
  */

--- a/tests/Integration/TermStoreSchemaUpdaterTest.php
+++ b/tests/Integration/TermStoreSchemaUpdaterTest.php
@@ -6,9 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Wikibase\TermStore\MediaWiki\TermStoreSchemaUpdater;
 use Wikimedia\Rdbms\DatabaseSqlite;
 
-/**
- * @group TermStoreWithMediaWikiCore
- */
 class TermStoreSchemaUpdaterTest extends TestCase {
 
 	public function testUpdaterCreatesTables() {


### PR DESCRIPTION
This unbreaks ScrutinizerCI and removes the need to have
"the evil hack" in every test file that depends on MW.

(TravisCI currently broken because one of the tests misses the hack)

![image](https://user-images.githubusercontent.com/146040/57724772-df46c680-768b-11e9-8fbd-0b11ace07b39.png)
