### PR TITLE
Fix typo in class name and add missing @covers

### DIFF
--- a/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
+++ b/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
@@ -5,6 +5,9 @@ namespace Wikibase\TermStore\MediaWiki\Tests\Unit\PackagePrivate;
 use PHPUnit\Framework\TestCase;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\InMemoryTermIdsAcquirer;
 
+/**
+ * @covers \Wikibase\TermStore\MediaWiki\PackagePrivate\InMemoryTermIdsAcquirer
+ */
 class InMemoryTermIdsAcquirerTest extends TestCase {
 
 	public function testAcquiresUniqueIdsForNonExistingTerms() {

--- a/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
+++ b/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
@@ -5,7 +5,7 @@ namespace Wikibase\TermStore\MediaWiki\Tests\Unit\PackagePrivate;
 use PHPUnit\Framework\TestCase;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\InMemoryTermIdsAcquirer;
 
-class InMemeoryTermIdsAcquirerTest extends TestCase {
+class InMemoryTermIdsAcquirerTest extends TestCase {
 
 	public function testAcquiresUniqueIdsForNonExistingTerms() {
 		$termsIdsAcquirer = new InMemoryTermIdsAcquirer();


### PR DESCRIPTION
Extracted from @JeroenDeDauw’s follow-up commit in #16.