### PR TITLE
Remove InMemoryTermIdsAcquirer::hasTerms() and tests

### DIFF
--- a/src/PackagePrivate/InMemoryTermIdsAcquirer.php
+++ b/src/PackagePrivate/InMemoryTermIdsAcquirer.php
@@ -46,19 +46,4 @@ class InMemoryTermIdsAcquirer implements TermIdsAcquirer, TermCleaner {
 		}
 	}
 
-	public function hasTerms() {
-		$empty = true;
-		// if there's any leaf element in terms then it's not empty, otherwise we consider
-		// the terms array empty even if it had some sub-arrays that are also empty by
-		// this definition
-		array_walk_recursive(
-			$this->terms,
-			function ( $element ) use ( &$empty ) {
-				$empty = false;
-			}
-		);
-
-		return !$empty;
-	}
-
 }

--- a/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
+++ b/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
@@ -119,42 +119,6 @@ class InMemoryTermIdsAcquirerTest extends TestCase {
 		$this->assertGreaterThan( max( $originalIds ), min( $newIds ) );
 	}
 
-	public function testHasTerms_returnsFalseAfterCleaningTerms() {
-		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
-
-		$ids = $termIdsAcquirer->acquireTermIds( [
-			'label' => [
-				'en' => 'the label',
-				'de' => 'die Bezeichnung',
-			],
-			'alias' => [
-				'en' => [ 'alias', 'another' ],
-			],
-			'description' => [ 'en' => 'the description' ],
-		] );
-
-		$termIdsAcquirer->cleanTerms( $ids );
-
-		$this->assertFalse( $termIdsAcquirer->hasTerms() );
-	}
-
-	public function testHasTerms_returnsTrueAfterAcquiringTermIds() {
-		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
-
-		$ids = $termIdsAcquirer->acquireTermIds( [
-			'label' => [
-				'en' => 'the label',
-				'de' => 'die Bezeichnung',
-			],
-			'alias' => [
-				'en' => [ 'alias', 'another' ],
-			],
-			'description' => [ 'en' => 'the description' ],
-		] );
-
-		$this->assertTrue( $termIdsAcquirer->hasTerms() );
-	}
-
 	public function testCleanTerms_keepsOtherIds() {
 		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
 


### PR DESCRIPTION
The method is not part of any interface, and was only used in tests. We don’t actually need it for anything, so let’s get rid of it.

---

I think the question that really should have been asked in #16 is this: Why do we *care* if `$terms` is `[]` or `[ 'label' => [ 'en' => [] ]`? And the answer is, we don’t. If there is no `hasTerms()` method, or if `hasTerms()` is implemented as it was ultimately merged, then as far as I can tell external code cannot tell the difference between the two (unless it peeks under the covers with `TestingAccessWrapper` or similar).

While implementing `cleanTerms()`, it was important to me for some reason that it does a proper cleanup, including removing those empty internal arrays. But there’s not really any need to test that for all eternity, so I think the unit test for it could just have been removed, instead of morphing it into this `hasTerms()` method which ultimately does something totally different than I originally intended in my pull request.