### PR TITLE
Add service to turn term IDs back into terms

### DIFF
--- a/src/PackagePrivate/InMemoryTermIdsAcquirer.php
+++ b/src/PackagePrivate/InMemoryTermIdsAcquirer.php
@@ -2,7 +2,7 @@
 
 namespace Wikibase\TermStore\MediaWiki\PackagePrivate;
 
-class InMemoryTermIdsAcquirer implements TermIdsAcquirer, TermCleaner {
+class InMemoryTermIdsAcquirer implements TermIdsAcquirer, TermIdsResolver, TermCleaner {
 
 	private $terms = [];
 	private $lastId = 0;
@@ -25,6 +25,20 @@ class InMemoryTermIdsAcquirer implements TermIdsAcquirer, TermCleaner {
 		}
 
 		return $ids;
+	}
+
+	public function resolveTermIds( array $termIds ): array {
+		$terms = [];
+		foreach ( $this->terms as $type => $termsOfType ) {
+			foreach ( $termsOfType as $lang => $termsOfLang ) {
+				foreach ( $termsOfLang as $term => $id ) {
+					if ( in_array( $id, $termIds ) ) {
+						$terms[$type][$lang][] = $term;
+					}
+				}
+			}
+		}
+		return $terms;
 	}
 
 	public function cleanTerms( array $termInLangIds ) {

--- a/src/PackagePrivate/TermIdsResolver.php
+++ b/src/PackagePrivate/TermIdsResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Wikibase\TermStore\MediaWiki\PackagePrivate;
+
+/**
+ * A service to turn term IDs terms,
+ * the inverse of {@link TermIdsAcquirer}.
+ */
+interface TermIdsResolver {
+
+	/**
+	 * Resolves terms for the given term IDs.
+	 *
+	 * Note that the information whether the leaf nodes were single strings or arrays of strings
+	 * is lost: while {@link TermIdsAcquirer::acquireTermIds} accepts both, this method always
+	 * returns arrays of strings.
+	 *
+	 * @param int[] $termIds
+	 * @return array containing terms per type per language.
+	 *  Example:
+	 * 	[
+	 *		'label' => [
+	 *			'en' => [ 'some label' ],
+	 *			'de' => [ 'another label' ],
+	 *			...
+	 *		],
+	 *		'alias' => [
+	 *			'en' => [ 'alias', 'another alias', ...],
+	 *			'de' => [ 'de alias' ],
+	 *			...
+	 *		],
+	 *		...
+	 *  ]
+	 */
+	public function resolveTermIds( array $termIds ): array;
+
+}

--- a/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
+++ b/tests/Unit/PackagePrivate/InMemoryTermIdsAcquirerTest.php
@@ -94,6 +94,43 @@ class InMemoryTermIdsAcquirerTest extends TestCase {
 		);
 	}
 
+	public function testResolveTermIds_returnsAcquiredTerms_butNotAllTerms() {
+		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
+
+		$termIds1 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [
+				'en' => 'some label',
+				'de' => 'eine Beschriftung',
+			],
+		] );
+		$termIds2 = $termIdsAcquirer->acquireTermIds( [
+			'label' => [
+				'de' => 'eine Beschriftung',
+			],
+			'alias' => [
+				'de' => [ 'ein Alias', 'noch ein Alias' ],
+			],
+		] );
+
+		$terms1 = $termIdsAcquirer->resolveTermIds( $termIds1 );
+		$terms2 = $termIdsAcquirer->resolveTermIds( $termIds2 );
+
+		$this->assertSame( [
+			'label' => [
+				'en' => [ 'some label' ],
+				'de' => [ 'eine Beschriftung' ],
+			],
+		], $terms1 );
+		$this->assertSame( [
+			'label' => [
+				'de' => [ 'eine Beschriftung' ],
+			],
+			'alias' => [
+				'de' => [ 'ein Alias', 'noch ein Alias' ],
+			],
+		], $terms2 );
+	}
+
 	public function testCleanTerms_doesNotReuseIds() {
 		$termIdsAcquirer = new InMemoryTermIdsAcquirer();
 


### PR DESCRIPTION
[T223994](https://phabricator.wikimedia.org/T223994)

- [x] interface
- [x] in-memory implementation
- [ ] database implementation

But we can also merge this pull request early and do the database part separately.