### PR TITLE
Inject ILoadBalancer instead of IDatabase instances

### DIFF
--- a/src/PackagePrivate/DatabaseTermIdsAcquirer.php
+++ b/src/PackagePrivate/DatabaseTermIdsAcquirer.php
@@ -6,6 +6,7 @@ use AppendIterator;
 use ArrayIterator;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\Util\ReplicaMasterAwareRecordIdsAcquirer;
 use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\ILoadBalancer;
 
 class DatabaseTermIdsAcquirer implements TermIdsAcquirer {
 
@@ -14,22 +15,20 @@ class DatabaseTermIdsAcquirer implements TermIdsAcquirer {
 	const TABLE_TERM_IN_LANG = 'wbt_term_in_lang';
 
 	/**
-	 * @var Database $dbw
+	 * @var ILoadBalancer
 	 */
-	private $dbw;
+	private $loadBalancer;
 
 	/**
-	 * @var Database $dbr
+	 * @var TypeIdsAcquirer
 	 */
-	private $dbr;
+	private $typeIdsAcquirer;
 
 	public function __construct(
-		IDatabase $dbw,
-		IDatabase $dbr,
+		ILoadBalancer $loadBalancer,
 		TypeIdsAcquirer $typeIdsAcquirer
 	) {
-		$this->dbw = $dbw;
-		$this->dbr = $dbr;
+		$this->loadBalancer = $loadBalancer;
 		$this->typeIdsAcquirer = $typeIdsAcquirer;
 	}
 
@@ -105,7 +104,7 @@ class DatabaseTermIdsAcquirer implements TermIdsAcquirer {
 
 	private function acquireTextIds( array $texts ) {
 		$textIdsAcquirer = new ReplicaMasterAwareRecordIdsAcquirer(
-			$this->dbw, $this->dbr, 'wbt_text', 'wbx_id' );
+			$this->loadBalancer, 'wbt_text', 'wbx_id' );
 
 		$textRecords = [];
 		foreach ( $texts as $text ) {
@@ -174,7 +173,7 @@ class DatabaseTermIdsAcquirer implements TermIdsAcquirer {
 
 	private function acquireTextInLangIds( array $langTextIds ) {
 		$textInLangIdsAcquirer = new ReplicaMasterAwareRecordIdsAcquirer(
-			$this->dbw, $this->dbr, 'wbt_text_in_lang', 'wbxl_id' );
+			$this->loadBalancer, 'wbt_text_in_lang', 'wbxl_id' );
 
 		$textInLangRecords = [];
 		foreach ( $langTextIds as $lang => $textIds ) {
@@ -240,7 +239,7 @@ class DatabaseTermIdsAcquirer implements TermIdsAcquirer {
 
 	private function acquireTermInLangIds( array $typeTextInLangIds ) {
 		$termInLangIdsAcquirer = new ReplicaMasterAwareRecordIdsAcquirer(
-			$this->dbw, $this->dbr, 'wbt_term_in_lang', 'wbtl_id' );
+			$this->loadBalancer, 'wbt_term_in_lang', 'wbtl_id' );
 
 		$termInLangRecords = [];
 		foreach ( $typeTextInLangIds as $typeId => $textInLangIds ) {

--- a/tests/Integration/PackagePrivate/DatabaseTermIdsAcquirerTest.php
+++ b/tests/Integration/PackagePrivate/DatabaseTermIdsAcquirerTest.php
@@ -6,8 +6,10 @@ use PHPUnit\Framework\TestCase;
 use Wikibase\TermStore\MediaWiki\TermStoreSchemaUpdater;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\DatabaseTermIdsAcquirer;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\InMemoryTypeIdsAcquirer;
+use Wikibase\TermStore\MediaWiki\Tests\Util\FakeLoadBalancer;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\DatabaseSqlite;
+use Wikimedia\Rdbms\ILoadBalancer;
 
 class DatabaseTermIdsAcquirerTest extends TestCase {
 
@@ -16,17 +18,24 @@ class DatabaseTermIdsAcquirerTest extends TestCase {
 	 */
 	private $db;
 
+	/**
+	 * @var ILoadBalancer
+	 */
+	private $loadBalancer;
+
 	public function setUp() {
 		$this->db = DatabaseSqlite::newStandaloneInstance( ':memory:' );
 		$this->db->sourceFile( TermStoreSchemaUpdater::getSqlFileAbsolutePath() );
+		$this->loadBalancer = new FakeLoadBalancer( [
+			'dbr' => $this->db,
+		] );
 	}
 
 	public function testAcquireTermIdsReturnsArrayOfIdsForAllTerms() {
 		$typeIdsAcquirer = new InMemoryTypeIdsAcquirer();
 
 		$dbTermIdsAcquirer = new DatabaseTermIdsAcquirer(
-			$this->db,
-			$this->db,
+			$this->loadBalancer,
 			$typeIdsAcquirer
 		);
 
@@ -54,8 +63,7 @@ class DatabaseTermIdsAcquirerTest extends TestCase {
 		);
 
 		$dbTermIdsAcquirer = new DatabaseTermIdsAcquirer(
-			$this->db,
-			$this->db,
+			$this->loadBalancer,
 			$typeIdsAcquirer
 		);
 
@@ -79,8 +87,7 @@ class DatabaseTermIdsAcquirerTest extends TestCase {
 		$typeIdsAcquirer = new InMemoryTypeIdsAcquirer();
 
 		$dbTermIdsAcquirer = new DatabaseTermIdsAcquirer(
-			$this->db,
-			$this->db,
+			$this->loadBalancer,
 			$typeIdsAcquirer
 		);
 
@@ -107,8 +114,7 @@ class DatabaseTermIdsAcquirerTest extends TestCase {
 		$typeIdsAcquirer = new InMemoryTypeIdsAcquirer();
 
 		$dbTermIdsAcquirer = new DatabaseTermIdsAcquirer(
-			$this->db,
-			$this->db,
+			$this->loadBalancer,
 			$typeIdsAcquirer
 		);
 
@@ -135,8 +141,7 @@ class DatabaseTermIdsAcquirerTest extends TestCase {
 		$typeIdsAcquirer = new InMemoryTypeIdsAcquirer();
 
 		$dbTermIdsAcquirer = new DatabaseTermIdsAcquirer(
-			$this->db,
-			$this->db,
+			$this->loadBalancer,
 			$typeIdsAcquirer
 		);
 
@@ -208,8 +213,7 @@ class DatabaseTermIdsAcquirerTest extends TestCase {
 		$aliasEnSameTermInLangId = (string)$this->db->insertId();
 
 		$dbTermIdsAcquirer = new DatabaseTermIdsAcquirer(
-			$this->db,
-			$this->db,
+			$this->loadBalancer,
 			$typeIdsAcquirer
 		);
 

--- a/tests/Integration/PackagePrivate/Util/ReplicaMasterAwareRecordIdsAcquirerTest.php
+++ b/tests/Integration/PackagePrivate/Util/ReplicaMasterAwareRecordIdsAcquirerTest.php
@@ -4,6 +4,7 @@ namespace Wikibase\TermStore\MediaWiki\Tests\Integration\PackagePrivate\Util;
 
 use PHPUnit\Framework\TestCase;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\Util\ReplicaMasterAwareRecordIdsAcquirer;
+use Wikibase\TermStore\MediaWiki\Tests\Util\FakeLoadBalancer;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\DatabaseSqlite;
 
@@ -134,8 +135,10 @@ class ReplicaMasterAwareRecordIdsAcquirerTest extends TestCase {
 
 	private function getTestSubjectInstance() {
 		return new ReplicaMasterAwareRecordIdsAcquirer(
-			$this->dbMaster,
-			$this->dbReplica,
+			new FakeLoadBalancer( [
+				'dbr' => $this->dbReplica,
+				'dbw' => $this->dbMaster,
+			] ),
 			self::TABLE_NAME,
 			self::ID_COLUMN
 		);

--- a/tests/Unit/MediaWikiDependent/MediaWikiNormalizedTermCleanerTest.php
+++ b/tests/Unit/MediaWikiDependent/MediaWikiNormalizedTermCleanerTest.php
@@ -5,6 +5,7 @@ namespace Wikibase\TermStore\MediaWiki\Tests\Unit\MediaWikiDependent;
 use MediaWikiTestCase;
 use Wikibase\TermStore\MediaWiki\PackagePrivate\MediaWikiNormalizedTermCleaner;
 use Wikibase\TermStore\MediaWiki\TermStoreSchemaUpdater;
+use Wikibase\TermStore\MediaWiki\Tests\Util\FakeLoadBalancer;
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\Rdbms\IMaintainableDatabase;
 
@@ -38,10 +39,9 @@ class MediaWikiNormalizedTermCleanerTest extends MediaWikiTestCase {
 	}
 
 	private function getCleaner(): MediaWikiNormalizedTermCleaner {
-		$lb = $this->createMock( ILoadBalancer::class );
-		$lb->method( 'getConnection' )
-			->willReturn( $this->db );
-		return new MediaWikiNormalizedTermCleaner( $lb );
+		return new MediaWikiNormalizedTermCleaner( new FakeLoadBalancer( [
+			'dbr' => $this->db,
+		] ) );
 	}
 
 	public function testCleanupEverything() {

--- a/tests/Util/FakeLoadBalancer.php
+++ b/tests/Util/FakeLoadBalancer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Wikibase\TermStore\MediaWiki\Tests\Util;
+
+use InvalidArgumentException;
+use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\Rdbms\LoadBalancer;
+
+class FakeLoadBalancer extends LoadBalancer {
+
+	/** @var IDatabase */
+	private $dbr;
+
+	/** @var IDatabase */
+	private $dbw;
+
+	/**
+	 * @param array $params should contain 'dbr' and optionally 'dbw' IDatabase instances
+	 */
+	public function __construct( array $params ) {
+		// no parent constructor call, we only use the LoadBalancer class so we don’t have to
+		// override every ILoadBalancer method – they’ll just crash if someone tries to use them
+		$this->dbr = $params['dbr'];
+		$this->dbw = $params['dbw'] ?? $this->dbr;
+	}
+
+	public function getConnection( $i, $groups = [], $domain = false, $flags = 0 ) {
+		switch ( $i ) {
+			case ILoadBalancer::DB_REPLICA:
+				return $this->dbr;
+			case ILoadBalancer::DB_MASTER:
+				return $this->dbw;
+			default:
+				throw new InvalidArgumentException( 'only DB_REPLICA and DB_MASTER supported' );
+		}
+	}
+
+	public function beginMasterChanges( $fname = __METHOD__ ) {
+		// no-op
+	}
+
+	public function commitMasterChanges( $fname = __METHOD__ ) {
+		// no-op
+	}
+
+	public function rollbackMasterChanges( $fname = __METHOD__ ) {
+		// no-op
+	}
+
+	public function __destruct() {
+		// no-op
+	}
+
+}


### PR DESCRIPTION
Injecting `IDatabase` instances means that a database connection must already be open just to instantiate the object (unless `DBConnRef` is used), which forces users to lazily instantiate the object unless they want to incur the cost of a database connection on every request. It’s better to inject an `ILoadBalancer` instead and defer acquiring the connection until we really need it; in fact, in some cases we may not need a `DB_MASTER` connection at all, and might instead be able to make do with just a `DB_REPLICA` connection.

A test helper class is included that can be used instead of a real load balancer to return one or two pre-configured connection objects.

(Also adds the missing declaration of `DatabaseTermIdsAcquirer`’s `$typeIdsAqcuirer`, while we’re at it.)

---

Also see [some related discussion on Gerrit](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/509340/1/client/includes/Hooks/ChangesListSpecialPageHookHandlers.php#93).