### PR TITLE
Add DatabaseTermIdsResolver

### DIFF
--- a/src/PackagePrivate/DatabaseTermIdsResolver.php
+++ b/src/PackagePrivate/DatabaseTermIdsResolver.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Wikibase\TermStore\MediaWiki\PackagePrivate;
+
+use InvalidArgumentException;
+use LogicException;
+use stdClass;
+use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\Rdbms\IResultWrapper;
+
+/**
+ * Term ID resolver using the normalized database schema.
+ *
+ * @license GPL-2.0-or-later
+ */
+class DatabaseTermIdsResolver implements TermIdsResolver {
+
+	/** @var TypeIdsResolver */
+	private $typeIdsResolver;
+
+	/** @var ILoadBalancer */
+	private $lb;
+
+	/** @var bool */
+	private $allowMasterFallback;
+
+	/** @var IDatabase */
+	private $dbr = null;
+
+	/** @var IDatabase */
+	private $dbw = null;
+
+	/** @var string[] stash of data returned from the {@link TypeIdsResolver} */
+	private $typeNames = [];
+
+	/**
+	 * @param TypeIdsResolver $typeIdsResolver
+	 * @param ILoadBalancer $lb
+	 * @param bool $allowMasterFallback Whether to fall back to the master database if the data from
+	 * the replica database is detected to be stale.
+	 */
+	public function __construct(
+		TypeIdsResolver $typeIdsResolver,
+		ILoadBalancer $lb,
+		$allowMasterFallback = false
+	) {
+		$this->typeIdsResolver = $typeIdsResolver;
+		$this->lb = $lb;
+		$this->allowMasterFallback = $allowMasterFallback;
+	}
+
+	/*
+	 * Term data is first read from the replica; if that returns less rows than we asked for, then
+	 * there are some new rows in the master that were not yet replicated, and we fall back to the
+	 * master if allowed. As the internal relations of the term store never change (for example, a
+	 * term_in_lang row will never suddenly point to a different text_in_lang), a master fallback
+	 * should never be necessary in any other case. However, callers need to consider where they
+	 * got the list of term IDs they pass into this method from: if it’s from a replica, they may
+	 * still see outdated data overall.
+	 */
+	public function resolveTermIds( array $termIds ): array {
+		$terms = [];
+
+		$replicaResult = $this->selectTerms( $this->getDbr(), $termIds );
+		$this->preloadTypes( $replicaResult );
+		$replicaTermIds = [];
+
+		foreach ( $replicaResult as $row ) {
+			$replicaTermIds[] = $row->wbtl_id;
+			$this->addResultTerms( $terms, $row );
+		}
+
+		if ( $this->allowMasterFallback && count( $replicaTermIds ) !== count( $termIds ) ) {
+			$masterTermIds = array_values( array_diff( $termIds, $replicaTermIds ) );
+			$masterResult = $this->selectTerms( $this->getDbw(), $masterTermIds );
+			$this->preloadTypes( $masterResult );
+			foreach ( $masterResult as $row ) {
+				$this->addResultTerms( $terms, $row );
+			}
+		}
+
+		return $terms;
+	}
+
+	private function selectTerms( IDatabase $db, array $termIds ): IResultWrapper {
+		return $db->select(
+			[ 'wbt_term_in_lang', 'wbt_text_in_lang', 'wbt_text' ],
+			[ 'wbtl_id', 'wbtl_type_id', 'wbxl_language', 'wbx_text' ],
+			[
+				'wbtl_id' => $termIds,
+				// join conditions
+				'wbtl_text_in_lang_id=wbxl_id',
+				'wbxl_text_id=wbx_id',
+			],
+			__METHOD__
+		);
+	}
+
+	private function preloadTypes( IResultWrapper $result ) {
+		$typeIds = [];
+		foreach ( $result as $row ) {
+			$typeId = $row->wbtl_type_id;
+			if ( !array_key_exists( $typeId, $this->typeNames ) ) {
+				$typeIds[$typeId] = true;
+			}
+		}
+		$this->typeNames += $this->typeIdsResolver->resolveTypeIds( array_keys( $typeIds ) );
+	}
+
+	private function addResultTerms( array &$terms, stdClass $row ) {
+		$type = $this->lookupType( $row->wbtl_type_id );
+		$lang = $row->wbxl_language;
+		$text = $row->wbx_text;
+		$terms[$type][$lang][] = $text;
+	}
+
+	private function lookupType( $typeId ) {
+		$typeName = $this->typeNames[$typeId] ?? null;
+		if ( $typeName === null ) {
+			throw new InvalidArgumentException(
+				'Type ID ' . $typeId . ' was requested but not preloaded!' );
+		}
+		return $typeName;
+	}
+
+	private function getDbr() {
+		if ( $this->dbr === null ) {
+			$this->dbr = $this->lb->getConnection( ILoadBalancer::DB_REPLICA );
+		}
+
+		return $this->dbr;
+	}
+
+	private function getDbw() {
+		if ( !$this->allowMasterFallback ) {
+			throw new LogicException( 'Master fallback not allowed!' );
+		}
+
+		if ( $this->dbw === null ) {
+			$this->dbw = $this->lb->getConnection( ILoadBalancer::DB_MASTER );
+		}
+
+		return $this->dbw;
+	}
+
+}

--- a/src/PackagePrivate/StaticTypeIdsStore.php
+++ b/src/PackagePrivate/StaticTypeIdsStore.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Wikibase\TermStore\MediaWiki\PackagePrivate;
+
+use DomainException;
+
+/**
+ * A type IDs acquirer and resolver that only encapsulates access to a static array of IDs.
+ */
+class StaticTypeIdsStore implements TypeIdsAcquirer, TypeIdsResolver {
+
+	/** @var int[] */
+	private $typeIdsByName;
+
+	/** @var string[] */
+	private $typeNamesById;
+
+	/**
+	 * @param int[] $types Array from type name to type ID.
+	 */
+	public function __construct( array $types ) {
+		$this->typeIdsByName = $types;
+		$this->typeNamesById = array_flip( $types );
+	}
+
+	public function acquireTypeIds( array $types ): array {
+		$ret = [];
+		foreach ( $types as $typeName ) {
+			if ( array_key_exists( $typeName, $this->typeIdsByName ) ) {
+				$ret[$typeName] = $this->typeIdsByName[$typeName];
+			} else {
+				throw new DomainException( 'Unknown type ' . $typeName . ' not supported!' );
+			}
+		}
+		return $ret;
+	}
+
+	public function resolveTypeIds( array $typeIds ): array {
+		$ret = [];
+		foreach ( $typeIds as $typeId ) {
+			if ( array_key_exists( $typeId, $this->typeNamesById ) ) {
+				$ret[$typeId] = $this->typeNamesById[$typeId];
+			}
+		}
+		return $ret;
+	}
+
+}

--- a/tests/Integration/PackagePrivate/DatabaseTermIdsResolverTest.php
+++ b/tests/Integration/PackagePrivate/DatabaseTermIdsResolverTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Wikibase\TermStore\MediaWiki\Tests\Integration\PackagePrivate;
+
+use PHPUnit\Framework\TestCase;
+use Wikibase\TermStore\MediaWiki\PackagePrivate\DatabaseTermIdsResolver;
+use Wikibase\TermStore\MediaWiki\PackagePrivate\StaticTypeIdsStore;
+use Wikibase\TermStore\MediaWiki\PackagePrivate\TypeIdsResolver;
+use Wikibase\TermStore\MediaWiki\TermStoreSchemaUpdater;
+use Wikibase\TermStore\MediaWiki\Tests\Util\FakeLoadBalancer;
+use Wikimedia\Rdbms\Database;
+use Wikimedia\Rdbms\DatabaseSqlite;
+use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\ILoadBalancer;
+
+/**
+ * @covers \Wikibase\TermStore\MediaWiki\PackagePrivate\DatabaseTermIdsResolver
+ */
+class DatabaseTermIdsResolverTest extends TestCase {
+
+	const TYPE_LABEL = 1;
+	const TYPE_DESCRIPTION = 2;
+	const TYPE_ALIAS = 3;
+
+	/** @var TypeIdsResolver */
+	private $typeIdsResolver;
+
+	/** @var IDatabase */
+	private $db;
+
+	public function setUp() {
+		$this->typeIdsResolver = new StaticTypeIdsStore( [
+			'label' => self::TYPE_LABEL,
+			'description' => self::TYPE_DESCRIPTION,
+			'alias' => self::TYPE_ALIAS,
+		] );
+		$this->db = DatabaseSqlite::newStandaloneInstance( ':memory:' );
+		$this->db->sourceFile( TermStoreSchemaUpdater::getSqlFileAbsolutePath() );
+	}
+
+	public function testCanResolveEverything() {
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'text' ] );
+		$text1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'Text' ] );
+		$text2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+		$textInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+		$textInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_DESCRIPTION, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang3Id = $this->db->insertId();
+
+		$resolver = new DatabaseTermIdsResolver(
+			$this->typeIdsResolver,
+			new FakeLoadBalancer( [
+				'dbr' => $this->db,
+			] )
+		);
+		$terms = $resolver->resolveTermIds( [ $termInLang1Id, $termInLang2Id, $termInLang3Id ] );
+
+		$this->assertSame( [
+			'label' => [
+				'en' => [ 'text' ],
+				'de' => [ 'Text' ],
+			],
+			'description' => [
+				'en' => [ 'text' ],
+			],
+		], $terms );
+	}
+
+	public function testReadsEverythingFromReplicaIfPossible() {
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'text' ] );
+		$text1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text',
+			[ 'wbx_text' => 'Text' ] );
+		$text2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+		$textInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_text_in_lang',
+			[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+		$textInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang1Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_DESCRIPTION, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+		$termInLang2Id = $this->db->insertId();
+		$this->db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang3Id = $this->db->insertId();
+
+		$dbw = $this->createMock( Database::class );
+		$dbw->expects( $this->never() )->method( 'query' );
+
+		$resolver = new DatabaseTermIdsResolver(
+			$this->typeIdsResolver,
+			new FakeLoadBalancer( [
+				'dbr' => $this->db,
+				'dbw' => $dbw,
+			] )
+		);
+		$resolver->resolveTermIds( [ $termInLang1Id, $termInLang2Id, $termInLang3Id ] );
+	}
+
+	public function testFallsBackToMasterIfNecessaryAndAllowed() {
+		$dbr = $this->db;
+		$dbw = DatabaseSqlite::newStandaloneInstance( ':memory:' );
+		$dbw->sourceFile( TermStoreSchemaUpdater::getSqlFileAbsolutePath() );
+		// both master and replica have most of the data
+		foreach ( [ $dbr, $dbw ] as $db ) {
+			// note: we assume that both DBs get the same insert IDs
+			$db->insert( 'wbt_text',
+				[ 'wbx_text' => 'text' ] );
+			$text1Id = $db->insertId();
+			$db->insert( 'wbt_text',
+				[ 'wbx_text' => 'Text' ] );
+			$text2Id = $db->insertId();
+			$db->insert( 'wbt_text_in_lang',
+				[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+			$textInLang1Id = $db->insertId();
+			$db->insert( 'wbt_text_in_lang',
+				[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+			$textInLang2Id = $db->insertId();
+			$db->insert( 'wbt_term_in_lang',
+				[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+			$termInLang1Id = $db->insertId();
+			$db->insert( 'wbt_term_in_lang',
+				[ 'wbtl_type_id' => self::TYPE_DESCRIPTION, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+			$termInLang2Id = $db->insertId();
+		}
+		// only master has the last term_in_lang row
+		$db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang3Id = $db->insertId();
+
+		$resolver = new DatabaseTermIdsResolver(
+			$this->typeIdsResolver,
+			new FakeLoadBalancer( [
+				'dbr' => $dbr,
+				'dbw' => $dbw,
+			] ),
+			true
+		);
+		$terms = $resolver->resolveTermIds( [ $termInLang1Id, $termInLang2Id, $termInLang3Id ] );
+
+		$this->assertSame( [
+			'label' => [
+				'en' => [ 'text' ],
+				'de' => [ 'Text' ],
+			],
+			'description' => [
+				'en' => [ 'text' ],
+			],
+		], $terms );
+	}
+
+	public function testDoesNotFallBackToMasterIfNotAllowed() {
+		$dbr = $this->db;
+		$dbw = DatabaseSqlite::newStandaloneInstance( ':memory:' );
+		$dbw->sourceFile( TermStoreSchemaUpdater::getSqlFileAbsolutePath() );
+		// both master and replica have most of the data
+		foreach ( [ $dbr, $dbw ] as $db ) {
+			// note: we assume that both DBs get the same insert IDs
+			$db->insert( 'wbt_text',
+				[ 'wbx_text' => 'text' ] );
+			$text1Id = $db->insertId();
+			$db->insert( 'wbt_text',
+				[ 'wbx_text' => 'Text' ] );
+			$text2Id = $db->insertId();
+			$db->insert( 'wbt_text_in_lang',
+				[ 'wbxl_language' => 'en', 'wbxl_text_id' => $text1Id ] );
+			$textInLang1Id = $db->insertId();
+			$db->insert( 'wbt_text_in_lang',
+				[ 'wbxl_language' => 'de', 'wbxl_text_id' => $text2Id ] );
+			$textInLang2Id = $db->insertId();
+			$db->insert( 'wbt_term_in_lang',
+				[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+			$termInLang1Id = $db->insertId();
+			$db->insert( 'wbt_term_in_lang',
+				[ 'wbtl_type_id' => self::TYPE_DESCRIPTION, 'wbtl_text_in_lang_id' => $textInLang1Id ] );
+			$termInLang2Id = $db->insertId();
+		}
+		// only master has the last term_in_lang row
+		$db->insert( 'wbt_term_in_lang',
+			[ 'wbtl_type_id' => self::TYPE_LABEL, 'wbtl_text_in_lang_id' => $textInLang2Id ] );
+		$termInLang3Id = $db->insertId();
+
+		$resolver = new DatabaseTermIdsResolver(
+			$this->typeIdsResolver,
+			new FakeLoadBalancer( [
+				'dbr' => $dbr,
+				'dbw' => $dbw,
+			] ),
+			false
+		);
+		$terms = $resolver->resolveTermIds( [ $termInLang1Id, $termInLang2Id, $termInLang3Id ] );
+
+		$this->assertSame( [
+			'label' => [
+				'en' => [ 'text' ],
+				// 'de' => [ 'Text' ], // this is the row missing from the replica
+			],
+			'description' => [
+				'en' => [ 'text' ],
+			],
+		], $terms );
+	}
+
+}


### PR DESCRIPTION
This is the database implementation of the `TermIdsResolver` interface, the inverse of `DatabaseTermIdsAcquirer`. For now, the implementation is fairly simple and uses a plain JOIN for most fields (though types already go through a `TypeIdResolver`); we’ll probably want to introduce caching (on several layers) in the future.

The test inserts are based on `MediaWikiNormalizedTermCleanerTest`.

---

Also includes the commits from #29, that one should be merged before this one.